### PR TITLE
Add HADES-R

### DIFF
--- a/lib/feeds/amsat/meta.json
+++ b/lib/feeds/amsat/meta.json
@@ -169,6 +169,17 @@
       }
     ]
   },
+  "SO-124": {
+    "aliases": ["Hades-R"],
+    "transponders": [
+      {
+        "id": "SO-124-FM",
+        "mode": "fm",
+        "downlink": { "min": 436.885, "max": 436.885 },
+        "uplink": { "min": 145.925, "max": 145.925 }
+      }
+    ]
+  },
   "SO-50": {
     "aliases": ["SAUDISAT 1C"],
     "links": [


### PR DESCRIPTION
HADES-R is active:
https://www.amsat.org/two-way-satellites/so-124-hades-r/